### PR TITLE
feat: Supply list of publish topics

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -51,19 +51,22 @@ data "aws_iam_policy_document" "forward_lambda_kms_sns_policy" {
       "kms:GenerateDataKey",
       "kms:Decrypt"
     ]
-    resources = [ var.common_tre_out_topic_kms_arn ]
+    resources = [ 
+      var.common_tre_out_topic_kms_arn,
+      var.common_da_eventbus_topic_kms_arn
+    ]
   }
 }
 
-resource "aws_iam_policy" "tre_out_topic_kms" {
-  name        = "${var.env}-${var.prefix}-foward-sns-key"
+resource "aws_iam_policy" "publish_topics_kms" {
+  name        = "${var.env}-${var.prefix}-forward-sns-key"
   description = "The KMS SNS key policy for forward lambda"
   policy      = data.aws_iam_policy_document.forward_lambda_kms_sns_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "packer_lambda_key" {
   role       = aws_iam_role.tre_forward_lambda_role.name
-  policy_arn = aws_iam_policy.tre_out_topic_kms.arn
+  policy_arn = aws_iam_policy.publish_topics_kms.arn
 }
 
 

--- a/iam.tf
+++ b/iam.tf
@@ -51,10 +51,7 @@ data "aws_iam_policy_document" "forward_lambda_kms_sns_policy" {
       "kms:GenerateDataKey",
       "kms:Decrypt"
     ]
-    resources = [ 
-      var.common_tre_out_topic_kms_arn,
-      var.common_da_eventbus_topic_kms_arn
-    ]
+    resources = var.publish_topics_kms_arns
   }
 }
 

--- a/lambda.tf
+++ b/lambda.tf
@@ -7,7 +7,7 @@ resource "aws_lambda_function" "tre_forward" {
   timeout       = 30
   environment {
     variables = {
-      "TRE_OUT_TOPIC_ARN" = var.tre_out_topic_arn
+      "PUBLISH_TOPIC_ARNS" = var.publish_topic_arns
     }
   }
   tracing_config {

--- a/lambda.tf
+++ b/lambda.tf
@@ -7,7 +7,7 @@ resource "aws_lambda_function" "tre_forward" {
   timeout       = 30
   environment {
     variables = {
-      "PUBLISH_TOPIC_ARNS" = var.publish_topic_arns
+      "PUBLISH_TOPIC_ARNS" = jsonencode(var.publish_topic_arns)
     }
   }
   tracing_config {

--- a/variables.tf
+++ b/variables.tf
@@ -13,8 +13,8 @@ variable "account_id" {
   type        = string
 }
 
-variable "tre_out_topic_arn" {
-  description = "ARN of the tre-out sns topic"
+variable "publish_topic_arns" {
+  description = "ARNs of the sns topics for the forwarder to publish to"
   type = string
 }
 
@@ -50,6 +50,11 @@ variable "ecr_uri_repo_prefix" {
 }
 
 variable "common_tre_out_topic_kms_arn" {
+  description = "ARN of the tre-out sns topic kms key"
+  type = string
+}
+
+variable "common_da_eventbus_topic_kms_arn" {
   description = "ARN of the tre-out sns topic kms key"
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,13 +53,3 @@ variable "publish_topics_kms_arns" {
   description = "ARNs of the kms keys for the topics to be published to"
   type = list(string)
 }
-
-variable "common_tre_out_topic_kms_arn" {
-  description = "ARN of the tre-out sns topic kms key"
-  type = string
-}
-
-variable "common_da_eventbus_topic_kms_arn" {
-  description = "ARN of the tre-out sns topic kms key"
-  type = string
-}

--- a/variables.tf
+++ b/variables.tf
@@ -13,11 +13,6 @@ variable "account_id" {
   type        = string
 }
 
-variable "publish_topic_arns" {
-  description = "ARNs of the sns topics for the forwarder to publish to"
-  type = string
-}
-
 variable "tre_dlq_alerts_lambda_function_name" {
   description = "TRE DLQ Alerts Lambda Function Name"
   type        = string
@@ -47,6 +42,16 @@ variable "ecr_uri_host" {
 variable "ecr_uri_repo_prefix" {
   description = "The prefix for Docker image repository names to use; e.g. foo/ in ACCOUNT.dkr.ecr.REGION.amazonaws.com/foo/tre-bar"
   type = string
+}
+
+variable "publish_topic_arns" {
+  description = "ARNs of the sns topics for the forwarder to publish to"
+  type = list(string)
+}
+
+variable "publish_topics_kms_arns" {
+  description = "ARNs of the kms keys for the topics to be published to"
+  type = list(string)
 }
 
 variable "common_tre_out_topic_kms_arn" {


### PR DESCRIPTION
We want to forward both to internal and da eventbus for the time being, to support the FCL -> FCL journey. This is part of a refactor to support a list of publish topics, which should support further flexibility in future even if we drop back down to one (da eventbus) in the near term.